### PR TITLE
bugfix: firefox issue showing only magenta

### DIFF
--- a/src/components/logo.astro
+++ b/src/components/logo.astro
@@ -24,22 +24,25 @@
 		.logo-c {
 			animation: 7s c steps(2, jump-end) infinite;
 			fill: #0ff;
-			x: 1;
+			mix-blend-mode: screen;
+			x: 1px;
 			y: 0;
 		}
 
 		.logo-m {
 			animation: 13s m steps(2, jump-end) infinite;
 			fill: #ff0;
+			mix-blend-mode: screen;
 			x: 0;
-			y: 1;
+			y: 1px;
 		}
 
 		.logo-y {
 			animation: 11s y steps(2, jump-end) infinite;
 			fill: #f0f;
-			x: 1;
-			y: 2;
+			mix-blend-mode: screen;
+			x: 1px;
+			y: 2px;
 		}
 	}
 


### PR DESCRIPTION
This is a fix for Firefox that shows only the magenta logo (#5). By adding in a `px` value and `mix-blend-mode: screen;` the logo will show up correctly.  I should note that the `px` value allows Firefox to animate and be offset like other browsers. Chrome browsers ignore this "fix" and still shows up correctly.
