### PR TITLE
Add CourseBuilder product operator workflow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: event, workshop run
 A purchasable pass to a specific Cohort that grants live-period benefits and lifetime access to that Cohort's Workshop recordings and materials.
 _Avoid_: event purchase, product
 
+**CourseBuilder Product**:
+An internal commerce item that can be sold through CourseBuilder and may later be linked to Workshop or Cohort resources.
+_Avoid_: standalone product, offer, SKU
+
 **Workshop Access**:
 A person's ability to view a Workshop or Cohort-specific materials through a Workshop Ticket, team seat claim, or supporter membership.
 _Avoid_: entitlement, permission, grant
@@ -103,9 +107,12 @@ _Avoid_: self-paced workshop, previous event, replay product
 - The first CodeTV commerce path should require sign-in before checkout because Workshop Tickets are relatively high-ticket purchases and CodeTV needs to check existing purchase/access state and purchase intent before sending the buyer to Stripe.
 - CodeTV owns its own CourseBuilder database and does not share Workshop, product, purchase, access, or Workshop content records with other CourseBuilder apps.
 - Workshop and Cohort commerce content lives in the CodeTV CourseBuilder database, not Sanity.
+- A **CourseBuilder Product** may exist without linked resources so CodeTV can verify Stripe product, price, checkout, and webhook plumbing before attaching it to Workshop or Cohort content.
+- A **CourseBuilder Product** may later be linked to one or more resources when the product should create resource-specific access.
 - Initial Workshop, Cohort, and Ticket records should be created and maintained with the existing CourseBuilder CLI or scripts rather than a new admin UI.
 - CodeTV should validate CLI workflows for creating, listing, and updating commerce content so CRUD UI is not required for the first implementation.
 - CodeTV should target full CLI/API parity for the CourseBuilder CLI; the CLI effectively defines the content and support operations contract.
+- CodeTV should expose CourseBuilder Product create/update through `/api/products` first, while treating upstream canonical CourseBuilder product mutation APIs as a likely future extraction because multiple CourseBuilder apps need the same operator workflow.
 - Primary sources for the CodeTV integration are `@coursebuilder/core` for the `/api/coursebuilder/*` routes, `aihero-cli` for the CLI contract, and AI Hero / Code with Antonio for implemented real-world route patterns.
 - When sources conflict, support what `aihero-cli` calls and prefer AI Hero / Code with Antonio working patterns over abstract package intent, unless `@coursebuilder/core` has a newer verified-compatible API.
 - CodeTV should mirror the Code with Antonio and AI Hero device-flow OAuth/token patterns so agents and operators can perform authenticated content CRUD and support operations.
@@ -130,7 +137,8 @@ _Avoid_: self-paced workshop, previous event, replay product
 - "Entitlement" names a CourseBuilder schema concept, not a CodeTV domain term — resolved: use **Workshop Access** in domain language.
 - The exact lag before a **Workshop** enters the **Workshop Archive** is intentionally unresolved; likely around 15 days, but supporter tier rules are not yet decided.
 - Supporter membership and archive access rules are deferred; the first implementation focuses on selling live **Workshop Tickets**.
-- CodeTV may offer products similar to other CourseBuilder apps, but those products are modeled as standalone CodeTV **Workshops**; for example, **Building Cool Apps with AI** is a CodeTV **Workshop**, while AI Hero is a separate product.
+- CodeTV may offer products similar to other CourseBuilder apps, but customer-facing paid learning products are modeled as CodeTV **Workshops**; for example, **Building Cool Apps with AI** is a CodeTV **Workshop**, while AI Hero is a separate product.
+- "Standalone product" is ambiguous — resolved: use **CourseBuilder Product** for the internal commerce primitive, not for a new customer-facing CodeTV product category.
 - Guest checkout and post-purchase transfer exist in other CourseBuilder apps, but CodeTV's first high-ticket Workshop Ticket path favors pre-checkout sign-in to reduce identity ambiguity and support existing-purchase checks.
 - Team ticket purchases are in scope for CodeTV because team seats are claimed through a **Team Claim Link** associated with a bulk coupon.
 - CourseBuilder's canonical team purchase model is a bulk purchase backed by a `bulkCoupon`; CodeTV should reuse the existing `NEW_BULK_COUPON`, `EXISTING_BULK_COUPON`, `INDIVIDUAL_TO_BULK_UPGRADE`, and `NEW_INDIVIDUAL_PURCHASE` purchase-type branching.
@@ -293,10 +301,11 @@ After opening the PR, continue with follow-up work in this order:
 8. Port/team-verify **Team Seat** / **Team Claim Link** / self-redeem flow.
 9. Add upload/media routes if Workshop import/upload workflow needs CLI support.
 10. Update agent-readiness artifacts as public surfaces stabilize:
-   - `robots.txt`
-   - sitemap audit
-   - `llms.txt`
-   - OAuth Protected Resource metadata
+
+- `robots.txt`
+- sitemap audit
+- `llms.txt`
+- OAuth Protected Resource metadata
 
 ### Agent-readiness SOP
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -301,11 +301,10 @@ After opening the PR, continue with follow-up work in this order:
 8. Port/team-verify **Team Seat** / **Team Claim Link** / self-redeem flow.
 9. Add upload/media routes if Workshop import/upload workflow needs CLI support.
 10. Update agent-readiness artifacts as public surfaces stabilize:
-
-- `robots.txt`
-- sitemap audit
-- `llms.txt`
-- OAuth Protected Resource metadata
+    - `robots.txt`
+    - sitemap audit
+    - `llms.txt`
+    - OAuth Protected Resource metadata
 
 ### Agent-readiness SOP
 

--- a/apps/website/src/coursebuilder/products.ts
+++ b/apps/website/src/coursebuilder/products.ts
@@ -1,0 +1,333 @@
+import { and, eq } from 'drizzle-orm';
+
+import { courseBuilderAdapter, db } from '../db';
+import { merchantPrice, merchantProduct, prices } from '../db/schema';
+import { getStripeProvider } from './stripe-provider';
+
+export type MerchantVerification = {
+	provider: 'stripe';
+	stripeProductId: string | null;
+	stripePriceId: string | null;
+	verified: boolean;
+	issues: string[];
+};
+
+type ParsedUsdPrice = {
+	amount: number;
+	unitAmount: string;
+};
+
+type CourseBuilderProduct = {
+	id: string;
+	name: string;
+	price?: {
+		id: string;
+		unitAmount: number | string;
+		nickname?: string | null;
+		[key: string]: unknown;
+	} | null;
+	[key: string]: unknown;
+};
+
+export class ProductServiceError extends Error {
+	constructor(
+		message: string,
+		public status = 400,
+		public code = 'PRODUCT_SERVICE_ERROR',
+		public details?: unknown,
+	) {
+		super(message);
+	}
+}
+
+export function parseUsdPrice(
+	value: unknown,
+	fieldName = 'price',
+): ParsedUsdPrice {
+	if (typeof value !== 'number' && typeof value !== 'string') {
+		throw new ProductServiceError(
+			`${fieldName} must be a USD dollar amount`,
+			400,
+			'INVALID_PRICE',
+		);
+	}
+
+	const raw = String(value).trim();
+	if (!/^\d+(\.\d{1,2})?$/.test(raw)) {
+		throw new ProductServiceError(
+			`${fieldName} must be a USD dollar amount with at most two decimals`,
+			400,
+			'INVALID_PRICE',
+		);
+	}
+
+	const amount = Number(raw);
+	if (!Number.isFinite(amount) || amount < 0) {
+		throw new ProductServiceError(
+			`${fieldName} must be greater than or equal to 0`,
+			400,
+			'INVALID_PRICE',
+		);
+	}
+
+	return {
+		amount,
+		unitAmount: String(amount),
+	};
+}
+
+function assertProductId(value: unknown): string {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new ProductServiceError(
+			'Product id is required',
+			400,
+			'MISSING_PRODUCT_ID',
+		);
+	}
+	return value.trim();
+}
+
+function assertProductName(value: unknown): string {
+	if (typeof value !== 'string') {
+		throw new ProductServiceError(
+			'name is required',
+			400,
+			'MISSING_PRODUCT_NAME',
+		);
+	}
+	const name = value.trim();
+	if (name.length < 2 || name.length > 90) {
+		throw new ProductServiceError(
+			'name must be between 2 and 90 characters',
+			400,
+			'INVALID_PRODUCT_NAME',
+		);
+	}
+	return name;
+}
+
+export async function verifyMerchantProduct(
+	productId: string,
+): Promise<MerchantVerification> {
+	const issues: string[] = [];
+	let stripeProductId: string | null = null;
+	let stripePriceId: string | null = null;
+
+	const merchantProductRow = await db.query.merchantProduct.findFirst({
+		where: and(
+			eq(merchantProduct.productId, productId),
+			eq(merchantProduct.status, 1),
+		),
+	});
+
+	if (!merchantProductRow) {
+		issues.push('missing_active_merchant_product');
+	} else {
+		stripeProductId = merchantProductRow.identifier;
+	}
+
+	const merchantPriceRow = merchantProductRow
+		? await db.query.merchantPrice.findFirst({
+				where: and(
+					eq(merchantPrice.merchantProductId, merchantProductRow.id),
+					eq(merchantPrice.status, 1),
+				),
+			})
+		: null;
+
+	if (!merchantPriceRow) {
+		issues.push('missing_active_merchant_price');
+	} else {
+		stripePriceId = merchantPriceRow.identifier;
+	}
+
+	const stripeProvider = getStripeProvider();
+	if (!stripeProvider) {
+		issues.push('stripe_provider_unavailable');
+	} else {
+		if (stripeProductId) {
+			try {
+				const stripeProduct = await stripeProvider.getProduct(stripeProductId);
+				if ('deleted' in stripeProduct && stripeProduct.deleted) {
+					issues.push('stripe_product_deleted');
+				} else if ('active' in stripeProduct && !stripeProduct.active) {
+					issues.push('stripe_product_inactive');
+				}
+			} catch (error) {
+				console.warn('product.verify.stripe-product-failed', {
+					productId,
+					stripeProductId,
+					error,
+				});
+				issues.push('stripe_product_not_retrievable');
+			}
+		}
+
+		if (stripePriceId) {
+			try {
+				const stripePrice = await stripeProvider.getPrice(stripePriceId);
+				if ('active' in stripePrice && !stripePrice.active) {
+					issues.push('stripe_price_inactive');
+				}
+			} catch (error) {
+				console.warn('product.verify.stripe-price-failed', {
+					productId,
+					stripePriceId,
+					error,
+				});
+				issues.push('stripe_price_not_retrievable');
+			}
+		}
+	}
+
+	return {
+		provider: 'stripe',
+		stripeProductId,
+		stripePriceId,
+		verified: issues.length === 0,
+		issues,
+	};
+}
+
+export async function createVerifiedProduct(input: {
+	name?: unknown;
+	price?: unknown;
+}) {
+	const name = assertProductName(input.name);
+	const price = parseUsdPrice(input.price);
+	let product: CourseBuilderProduct | null = null;
+
+	try {
+		product = (await courseBuilderAdapter.createProduct({
+			name,
+			price: price.amount,
+			type: 'self-paced',
+			quantityAvailable: -1,
+			state: 'draft',
+			visibility: 'unlisted',
+		})) as CourseBuilderProduct;
+
+		const merchantVerification = await verifyMerchantProduct(product.id);
+		if (!merchantVerification.verified) {
+			throw new ProductServiceError(
+				'Product merchant verification failed',
+				502,
+				'PRODUCT_MERCHANT_VERIFICATION_FAILED',
+				merchantVerification,
+			);
+		}
+		return { product, merchantVerification };
+	} catch (error) {
+		if (product?.id) {
+			try {
+				await courseBuilderAdapter.archiveProduct(product.id);
+			} catch (cleanupError) {
+				console.warn('product.create.cleanup-failed', {
+					productId: product.id,
+					cleanupError,
+				});
+			}
+		}
+
+		if (error instanceof ProductServiceError) throw error;
+		const message =
+			error instanceof Error ? error.message : 'Product creation failed';
+		throw new ProductServiceError(
+			message,
+			/Payment provider|Merchant account/i.test(message) ? 503 : 500,
+			'PRODUCT_CREATE_FAILED',
+		);
+	}
+}
+
+export async function updateVerifiedProductPatch(input: {
+	id: unknown;
+	name?: unknown;
+	price?: unknown;
+}) {
+	const id = assertProductId(input.id);
+	const hasName = input.name !== undefined;
+	const hasPrice = input.price !== undefined;
+
+	if (!hasName && !hasPrice) {
+		throw new ProductServiceError(
+			'Provide at least one field to update: name or price',
+			400,
+			'NO_PRODUCT_UPDATES',
+		);
+	}
+
+	const currentProduct = (await courseBuilderAdapter.getProduct(
+		id,
+	)) as CourseBuilderProduct | null;
+	if (!currentProduct) {
+		throw new ProductServiceError(
+			'Product not found',
+			404,
+			'PRODUCT_NOT_FOUND',
+		);
+	}
+
+	const name = hasName ? assertProductName(input.name) : currentProduct.name;
+	const parsedPrice = hasPrice ? parseUsdPrice(input.price) : null;
+
+	if (parsedPrice && !currentProduct.price) {
+		throw new ProductServiceError(
+			'Product has no price to update',
+			409,
+			'PRODUCT_PRICE_MISSING',
+		);
+	}
+
+	const mergedProduct: CourseBuilderProduct = {
+		...currentProduct,
+		name,
+		price: currentProduct.price
+			? {
+					...currentProduct.price,
+					unitAmount: parsedPrice
+						? parsedPrice.amount
+						: currentProduct.price.unitAmount,
+					nickname: name,
+				}
+			: currentProduct.price,
+	};
+
+	try {
+		let product = (await courseBuilderAdapter.updateProduct(
+			mergedProduct as any,
+		)) as CourseBuilderProduct;
+
+		// CourseBuilder adapter currently floors decimal dollars into the local Price row on update.
+		// Correct CodeTV's local source of truth after the Stripe/default-price recreation succeeds.
+		if (parsedPrice && currentProduct.price?.id) {
+			await db
+				.update(prices)
+				.set({ unitAmount: parsedPrice.unitAmount, nickname: name })
+				.where(eq(prices.id, currentProduct.price.id));
+			product = (await courseBuilderAdapter.getProduct(
+				id,
+			)) as CourseBuilderProduct;
+		}
+
+		const merchantVerification = await verifyMerchantProduct(id);
+		if (!merchantVerification.verified) {
+			throw new ProductServiceError(
+				'Product merchant verification failed',
+				502,
+				'PRODUCT_MERCHANT_VERIFICATION_FAILED',
+				merchantVerification,
+			);
+		}
+		return { product, merchantVerification };
+	} catch (error) {
+		if (error instanceof ProductServiceError) throw error;
+		const message =
+			error instanceof Error ? error.message : 'Product update failed';
+		throw new ProductServiceError(
+			message,
+			/Payment provider|Merchant account/i.test(message) ? 503 : 500,
+			'PRODUCT_UPDATE_FAILED',
+		);
+	}
+}

--- a/apps/website/src/pages/api/products.ts
+++ b/apps/website/src/pages/api/products.ts
@@ -4,10 +4,39 @@ import { and, asc, eq, or, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { contentResourceResource, products } from '../../db/schema';
 import { getUserAbilityForRequest } from '../../server/ability';
+import {
+	createVerifiedProduct,
+	ProductServiceError,
+	updateVerifiedProductPatch,
+	verifyMerchantProduct,
+} from '../../coursebuilder/products';
 import { withSkill } from '../../server/with-skill';
 
 function json(body: unknown, init: ResponseInit = {}) {
 	return Response.json(body, init);
+}
+
+async function readJsonBody(request: Request) {
+	try {
+		return await request.json();
+	} catch {
+		return null;
+	}
+}
+
+function productServiceErrorResponse(error: unknown) {
+	if (error instanceof ProductServiceError) {
+		return json(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+			},
+			{ status: error.status },
+		);
+	}
+
+	throw error;
 }
 
 const productWithFullStructure = {
@@ -69,6 +98,11 @@ export const GET: APIRoute = async ({ request }) =>
 			if (!product)
 				return json({ error: 'Product not found' }, { status: 404 });
 
+			if (canSeeInactiveProducts) {
+				const merchantVerification = await verifyMerchantProduct(product.id);
+				return json({ ...product, merchantVerification });
+			}
+
 			return json(product);
 		}
 
@@ -78,4 +112,65 @@ export const GET: APIRoute = async ({ request }) =>
 		});
 
 		return json(result);
+	})(request);
+
+export const POST: APIRoute = async ({ request }) =>
+	withSkill(async (request) => {
+		const { user, ability } = await getUserAbilityForRequest(request);
+		if (!user)
+			return json({ error: 'Authentication required' }, { status: 401 });
+		if (!ability.can('create', 'Content')) {
+			return json({ error: 'Forbidden' }, { status: 403 });
+		}
+
+		const body = await readJsonBody(request);
+		if (!body || typeof body !== 'object') {
+			return json({ error: 'JSON body is required' }, { status: 400 });
+		}
+
+		try {
+			const { product, merchantVerification } = await createVerifiedProduct(
+				body as { name?: unknown; price?: unknown },
+			);
+			return json(
+				{ success: true, product, merchantVerification },
+				{ status: 201 },
+			);
+		} catch (error) {
+			return productServiceErrorResponse(error);
+		}
+	})(request);
+
+export const PUT: APIRoute = async ({ request }) =>
+	withSkill(async (request) => {
+		const { user, ability } = await getUserAbilityForRequest(request);
+		if (!user)
+			return json({ error: 'Authentication required' }, { status: 401 });
+		if (!ability.can('update', 'Content')) {
+			return json({ error: 'Forbidden' }, { status: 403 });
+		}
+
+		const body = await readJsonBody(request);
+		if (!body || typeof body !== 'object') {
+			return json({ error: 'JSON body is required' }, { status: 400 });
+		}
+
+		const payload = body as {
+			id?: unknown;
+			productId?: unknown;
+			name?: unknown;
+			price?: unknown;
+		};
+
+		try {
+			const { product, merchantVerification } =
+				await updateVerifiedProductPatch({
+					id: payload.id ?? payload.productId,
+					name: payload.name,
+					price: payload.price,
+				});
+			return json({ success: true, product, merchantVerification });
+		} catch (error) {
+			return productServiceErrorResponse(error);
+		}
 	})(request);

--- a/apps/website/src/pages/api/products.ts
+++ b/apps/website/src/pages/api/products.ts
@@ -36,7 +36,14 @@ function productServiceErrorResponse(error: unknown) {
 		);
 	}
 
-	throw error;
+	console.error('product.route.unexpected-error', { error });
+	return json(
+		{
+			error: 'Internal server error',
+			code: 'INTERNAL_SERVER_ERROR',
+		},
+		{ status: 500 },
+	);
 }
 
 const productWithFullStructure = {
@@ -117,8 +124,7 @@ export const GET: APIRoute = async ({ request }) =>
 export const POST: APIRoute = async ({ request }) =>
 	withSkill(async (request) => {
 		const { user, ability } = await getUserAbilityForRequest(request);
-		if (!user)
-			return json({ error: 'Authentication required' }, { status: 401 });
+		if (!user) return json({ error: 'Unauthorized' }, { status: 401 });
 		if (!ability.can('create', 'Content')) {
 			return json({ error: 'Forbidden' }, { status: 403 });
 		}
@@ -144,8 +150,7 @@ export const POST: APIRoute = async ({ request }) =>
 export const PUT: APIRoute = async ({ request }) =>
 	withSkill(async (request) => {
 		const { user, ability } = await getUserAbilityForRequest(request);
-		if (!user)
-			return json({ error: 'Authentication required' }, { status: 401 });
+		if (!user) return json({ error: 'Unauthorized' }, { status: 401 });
 		if (!ability.can('update', 'Content')) {
 			return json({ error: 'Forbidden' }, { status: 403 });
 		}

--- a/plans/coursebuilder-product-operator-workflow.md
+++ b/plans/coursebuilder-product-operator-workflow.md
@@ -1,0 +1,175 @@
+# Plan: CourseBuilder Product Operator Workflow
+
+> Source PRD: GitHub issue #66 — Add CourseBuilder Product create/update operator workflow
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Routes**: use the existing operator products route: `GET /api/products?slugOrId=...`, `POST /api/products`, and `PUT /api/products`.
+- **CLI surface**: expose top-level product commands: `cb product create --name ... --price ... --app codetv` and `cb product update <product-id> --name ... --price ... --app codetv`.
+- **Price semantics**: API and CLI prices are USD dollars with at most two decimal places. Stripe cents exist only at the Stripe provider boundary.
+- **Authentication and authorization**: use existing operator authentication and existing content abilities: create permission for product creation and update permission for product updates.
+- **Deep module**: product mutation, merchant verification, and cleanup behavior live in a reusable CourseBuilder product service. HTTP routes stay thin and only own auth, validation, response status, and JSON formatting.
+- **Key models**: CourseBuilder Product, Price, MerchantProduct, and MerchantPrice.
+- **Merchant verification**: successful mutations return the Product plus a merchant verification summary for the active Stripe product and price linkage.
+- **Failure behavior**: product mutations fail hard when merchant verification fails. Cleanup is best-effort and uses soft-delete/archive behavior rather than hard deletion.
+- **Public/private boundary**: merchant verification details are operator-only. Public reads should not expose Stripe IDs or merchant wiring if the read surface changes later.
+- **Schema**: no database schema changes are expected for this feature.
+- **Future extraction**: this remains app-local for CodeTV now, but should be considered for upstream CourseBuilder standardization after the workflow is validated.
+
+---
+
+## Phase 1: Create a verified no-resource Product through the API
+
+**User stories**: 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 27, 28, 31, 34
+
+### What to build
+
+Implement the narrowest complete product creation path for operators. An authenticated operator can call `POST /api/products` with a product name and USD price. The system creates a no-resource CourseBuilder Product, creates the active local price, syncs the Stripe product and Stripe price, creates local merchant linkage, verifies that linkage, and returns the product plus merchant verification summary.
+
+### Acceptance criteria
+
+- [ ] `POST /api/products` accepts a minimal payload with product name and USD price.
+- [ ] Price input uses USD dollars and accepts up to two decimal places.
+- [ ] Price input with more than two decimal places is rejected with a clear validation error.
+- [ ] New products default to the agreed minimal smoke shape: one-time product, unlimited quantity, draft, unlisted, no linked resources.
+- [ ] Unauthorized requests fail.
+- [ ] Operators without create permission fail.
+- [ ] Successful creation returns the CourseBuilder Product.
+- [ ] Successful creation returns merchant verification including provider, Stripe product identifier, Stripe price identifier, and verified status.
+- [ ] Successful creation creates active local Product, Price, MerchantProduct, and MerchantPrice records.
+- [ ] Successful creation creates active Stripe Product and Stripe Price records.
+- [ ] A mutation does not return success unless merchant linkage is verified.
+
+---
+
+## Phase 2: Add product create CLI command
+
+**User stories**: 2, 25, 26, 29
+
+### What to build
+
+Expose the product creation API through a top-level operator CLI command. The CLI accepts the same minimal operator language as the API, sends the request to CodeTV, and prints structured output containing the product and merchant verification summary.
+
+### Acceptance criteria
+
+- [ ] `cb product create --name <name> --price <usd> --app codetv` sends `POST /api/products`.
+- [ ] CLI price input uses the same USD dollar semantics as the API.
+- [ ] CLI output includes the created product identifier.
+- [ ] CLI output includes merchant verification details.
+- [ ] CLI validation and API validation failures are visible as structured errors.
+- [ ] The command is top-level under `product`, not hidden under generic CRUD wording.
+- [ ] The command suggests useful next actions such as fetching or updating the product.
+
+---
+
+## Phase 3: Patch-update product name and price through the API
+
+**User stories**: 14, 15, 16, 17, 18, 19, 20, 21, 28
+
+### What to build
+
+Implement patch-based product updates for the narrow fields required by the smoke workflow. An authenticated operator can update the product name, price, or both. The server fetches the existing Product, merges only supported patch fields, preserves unsupported state and existing resource links, syncs the Stripe product name, creates a new Stripe Price when the price changes, deactivates replaced price records, verifies the resulting merchant linkage, and returns the product plus merchant verification summary.
+
+### Acceptance criteria
+
+- [ ] `PUT /api/products` accepts a product identifier plus optional name and price fields.
+- [ ] Update uses patch semantics and does not require the full product shape from the caller.
+- [ ] Unsupported fields are ignored or rejected clearly without mutating product state.
+- [ ] Name updates sync to the local product and Stripe product.
+- [ ] Price updates use USD dollars and the same two-decimal validation rule as creation.
+- [ ] Price changes create a new active Stripe Price.
+- [ ] Replaced Stripe Price records are deactivated where possible.
+- [ ] Replaced local MerchantPrice records are deactivated.
+- [ ] Existing product type, fields, status, quantity, and resource links are preserved unless explicitly supported later.
+- [ ] Operators without update permission fail.
+- [ ] Successful update returns the updated Product and merchant verification summary.
+- [ ] A mutation does not return success unless the updated merchant linkage is verified.
+
+---
+
+## Phase 4: Add product update CLI command
+
+**User stories**: 2, 16, 17, 21, 25, 26, 29
+
+### What to build
+
+Expose the patch update API through a top-level operator CLI command. The CLI accepts a product identifier and optional name and price flags, sends the patch to CodeTV, and prints structured output with the updated product and merchant verification summary.
+
+### Acceptance criteria
+
+- [ ] `cb product update <product-id> --name <name> --app codetv` sends a name patch.
+- [ ] `cb product update <product-id> --price <usd> --app codetv` sends a price patch.
+- [ ] `cb product update <product-id> --name <name> --price <usd> --app codetv` sends both fields in one patch.
+- [ ] CLI price input uses the same USD dollar semantics as the API.
+- [ ] CLI output includes the updated product identifier.
+- [ ] CLI output includes merchant verification details.
+- [ ] CLI errors are structured when validation, auth, update, or merchant verification fails.
+- [ ] The command is top-level under `product`, not hidden under generic CRUD wording.
+- [ ] The command suggests useful next actions such as fetching the product or starting checkout smoke verification.
+
+---
+
+## Phase 5: Expose operator merchant verification on product reads
+
+**User stories**: 22, 23, 33, 35
+
+### What to build
+
+Enhance authenticated operator product reads so a product fetch can answer whether the product is sellable without direct database or Stripe spelunking. Existing product fetch behavior remains compatible, but operator responses include merchant verification details by default.
+
+### Acceptance criteria
+
+- [ ] Authenticated operator `GET /api/products?slugOrId=<id-or-slug>` includes merchant verification for the returned product.
+- [ ] Authenticated operator product list responses include merchant verification where practical without making the list endpoint unusably expensive.
+- [ ] Merchant verification identifies missing or inactive local merchant linkage.
+- [ ] Merchant verification identifies the active Stripe product and price identifiers when available.
+- [ ] Existing CLI product list/get behavior remains compatible.
+- [ ] Merchant verification details remain operator-only and are not exposed through public product reads if route access changes later.
+
+---
+
+## Phase 6: Failure handling and cleanup hardening
+
+**User stories**: 11, 12, 13, 32, 35
+
+### What to build
+
+Harden the product mutation path so partial failures are explicit, observable, and as safe as possible. Because DB writes and Stripe calls cannot be one transaction, mutations fail hard, verify after mutation, attempt best-effort archival/deactivation when partial records are identifiable, and log cleanup failures separately.
+
+### Acceptance criteria
+
+- [ ] Product creation returns failure if Stripe product creation fails.
+- [ ] Product creation returns failure if Stripe price creation fails.
+- [ ] Product creation returns failure if local merchant linkage cannot be verified.
+- [ ] Product update returns failure if merchant linkage cannot be verified after update.
+- [ ] Failed creation attempts best-effort soft cleanup/archive of identifiable local product state.
+- [ ] Failed update attempts best-effort preservation or cleanup of identifiable merchant state.
+- [ ] Cleanup prefers archive/deactivation over hard delete.
+- [ ] Cleanup failures are logged separately from the original mutation failure.
+- [ ] Failure responses are structured and do not imply that a product is sellable.
+- [ ] Logs provide enough context for support/debugging without exposing secrets.
+
+---
+
+## Phase 7: End-to-end smoke runbook
+
+**User stories**: 24, 25, 26, 30, 34, 35
+
+### What to build
+
+Document and validate the operator smoke workflow that proves the CourseBuilder Product foundation is ready for checkout work. The runbook should create a no-resource product, update the name, update the price, fetch the product, confirm merchant verification, and record what to inspect in CodeTV and Stripe. It should also note that this app-local workflow is a candidate for upstream CourseBuilder extraction after validation.
+
+### Acceptance criteria
+
+- [ ] Runbook shows how to create a smoke product through the CLI.
+- [ ] Runbook shows how to update the smoke product name through the CLI.
+- [ ] Runbook shows how to update the smoke product price through the CLI.
+- [ ] Runbook shows how to fetch the smoke product and inspect merchant verification.
+- [ ] Runbook lists the local CourseBuilder records expected after creation.
+- [ ] Runbook lists the local CourseBuilder records expected after a price update.
+- [ ] Runbook lists the Stripe records expected after creation and update.
+- [ ] Runbook explains that products can be no-resource smoke artifacts before Workshop Ticket checkout is implemented.
+- [ ] Runbook notes the future upstream CourseBuilder extraction opportunity.
+- [ ] Running the smoke workflow gives enough confidence to proceed to checkout/session/webhook verification.


### PR DESCRIPTION
## Summary

Adds the app-local CourseBuilder Product operator workflow for CodeTV commerce smoke testing.

- Adds a CourseBuilder product service for minimal no-resource product create/update
- Adds `POST /api/products` and `PUT /api/products`
- Adds operator merchant verification to single product reads
- Keeps price semantics in USD dollars and validates max two decimals
- Returns product plus merchant verification summary
- Documents the plan and updates domain context for **CourseBuilder Product**

Closes #66.

## Checks

- `pnpm --filter @codetv/website astro check` fails on 8 existing unrelated diagnostics; no diagnostics from the new product route/service after import fix.
- CourseBuilder CLI changes live in a separate repo/PR because `cb product create/update` is implemented in `badass-courses/course-builder`.

## Manual follow-up

After the paired CLI PR lands, run the product smoke flow against a configured CodeTV environment with CourseBuilder Stripe env present:

```bash
cb product create --name "Smoke Product" --price 19.99 --app codetv
cb product update <product-id> --name "Smoke Product Updated" --app codetv
cb product update <product-id> --price 29.99 --app codetv
cb product list --slug-or-id <product-id> --app codetv
```
