### PR TITLE
Issue 71: Add default column width for slimmer viewport widths

### DIFF
--- a/apps/website/src/components/design-system/grid.astro
+++ b/apps/website/src/components/design-system/grid.astro
@@ -22,6 +22,8 @@ const { columns = 3 } = Astro.props;
 		gap: var(--gap);
 		justify-content: center;
 		max-inline-size: 90cqi;
+		grid-template-columns: 1fr;
+		width: 100%;
 
 		@media (min-width: 600px) {
 			grid-template-columns: repeat(


### PR DESCRIPTION
**Expected Result**
When I load the hackathon pages into viewports slimmer than 1024px, I expect to see the hackathon cards load and their contents be clearly legible.

**Current Result**
When I load the hackathon pages, any Cards rendered in a Grid component are rendered in 1px columns with text overflowing. This occurs despite template column definitions at a minimum viewport width of 600px and 1024px. This is due to a lack of enforced grid column width by default. This, in combination with the flex styling and other grid definitions, caused the thin render width.

**Changes**
This PR simply adds a default template column width and a width of 100% to ensure content fills the space. This fixes the grid matrixes for both the hackathons main page and submission page.

Hackathon main page (before/after) - 

<img width="360" height="292" alt="Screenshot 2026-06-23 at 9 56 39 AM" src="https://github.com/user-attachments/assets/fa0b2fd4-9850-4804-a796-064182145202" />
<img width="360" height="292" alt="Screenshot 2026-06-23 at 9 57 00 AM" src="https://github.com/user-attachments/assets/f3814b81-5971-4eb8-ba36-3a735afdb2aa" />

---

Hackathon submission page (before/after) -

<img width="360" height="293" alt="Screenshot 2026-06-23 at 9 57 19 AM" src="https://github.com/user-attachments/assets/90698f13-1a15-4d59-a908-3054bab4edca" />
<img width="360" height="293" alt="Screenshot 2026-06-23 at 9 57 49 AM" src="https://github.com/user-attachments/assets/113c0777-0cef-4b77-8a4e-110447a612c7" />
